### PR TITLE
Bump version in example 2, add "with:"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,8 @@ jobs:
           node-version: "13.9.0"
       - name: Jaid/action-sync-node-meta
         uses: jaid/action-sync-node-meta@v1.3.1
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            githubToken: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### overwrite-github
@@ -71,9 +72,10 @@ jobs:
         with:
           node-version: "13.9.0"
       - name: Jaid/action-sync-node-meta
-        uses: jaid/action-sync-node-meta@v1.0.0
-        direction: overwrite-github
-        githubToken: ${{ secrets.customGithubToken }}
+        uses: jaid/action-sync-node-meta@v1.3.1
+          with:
+            direction: overwrite-github
+            githubToken: ${{ secrets.customGithubToken }}
 ```
 
 


### PR DESCRIPTION
The version in the second example was still v1.0.0;
`direction` and `githubToken` were at the same level as `uses:`, which throws. I've added `with:` to correctly pass them.